### PR TITLE
Use stricter warning policy and update expected error message for TestUnsupportedFrames test

### DIFF
--- a/multibody/parsing/detail_sdf_parser.cc
+++ b/multibody/parsing/detail_sdf_parser.cc
@@ -70,7 +70,7 @@ void ThrowIfPoseFrameSpecified(sdf::ElementPtr element) {
     if (!frame_name.empty()) {
       throw std::runtime_error(
           "<pose relative_to='{non-empty}'/> is presently not supported "
-          "in <inertial/> or <model/> tags.");
+          "in <model/> tags.");
     }
   }
 }
@@ -446,9 +446,12 @@ std::string LoadSdf(
   data_source.DemandExactlyOne();
 
   std::string root_dir;
+  sdf::ParserConfig parser_config = sdf::ParserConfig::GlobalConfig();
+  parser_config.SetWarningsPolicy(sdf::EnforcementPolicy::ERR);
+
   if (data_source.file_name) {
     const std::string full_path = GetFullPath(*data_source.file_name);
-    ThrowAnyErrors(root->Load(full_path));
+    ThrowAnyErrors(root->Load(full_path, parser_config));
     // Uses the directory holding the SDF to be the root directory
     // in which to search for files referenced within the SDF file.
     size_t found = full_path.find_last_of("/\\");
@@ -461,7 +464,8 @@ std::string LoadSdf(
     }
   } else {
     DRAKE_DEMAND(data_source.file_contents);
-    ThrowAnyErrors(root->LoadSdfString(*data_source.file_contents));
+    ThrowAnyErrors(
+        root->LoadSdfString(*data_source.file_contents, parser_config));
   }
 
   return root_dir;

--- a/multibody/parsing/test/detail_sdf_parser_test.cc
+++ b/multibody/parsing/test/detail_sdf_parser_test.cc
@@ -897,12 +897,20 @@ GTEST_TEST(SdfParser, TestSupportedFrames) {
 </model>)");
 }
 
-void FailWithUnsupportedRelativeTo(const std::string& inner) {
+void FailWithUnsupportedRelativeToInModel(const std::string& inner) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       ParseTestString(inner),
       std::runtime_error,
       R"(<pose relative_to='\{non-empty\}'/> is presently not supported )"
-      R"(in <inertial/> or <model/> tags.)");
+      R"(in <model/> tags.)");
+}
+
+void FailWithUnsupportedRelativeToInInertial(const std::string& inner) {
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ParseTestString(inner),
+      std::runtime_error,
+      R"([\s\S]*XML Attribute\[relative_to\] in element\[pose\] not defined )"
+      R"(in SDF[\.\s\S]*)");
 }
 
 void FailWithInvalidWorld(const std::string& inner) {
@@ -948,12 +956,12 @@ GTEST_TEST(SdfParser, TestUnsupportedFrames) {
 )", bad_name));
   }
 
-  FailWithUnsupportedRelativeTo(R"(
+  FailWithUnsupportedRelativeToInModel(R"(
 <model name='bad'>
   <pose relative_to='invalid_usage'/>
   <link name='dont_crash_plz'/>  <!-- Need at least one frame -->
 </model>)");
-  FailWithUnsupportedRelativeTo(R"(
+  FailWithUnsupportedRelativeToInInertial(R"(
 <model name='bad'>
   <frame name='my_frame'/>
   <link name='a'>


### PR DESCRIPTION
libsdformat now emits an error when //inertial/pose/@relative_to is
non-empty, so this patch updates the error message to match the one
emitted by libsdformat. Support for //model/pose/@relative_to in Drake
is in the pipeline, but I kept the test that considers that invalid
until we merge #14401.

Signed-off-by: Addisu Z. Taddese <addisu@openrobotics.org>