### PR TITLE
Add reusable configuration mechanism for malformed input

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_package_library(
         ":cond",
         ":copyable_unique_ptr",
         ":default_scalars",
+        ":diagnostic_policy",
         ":double",
         ":drake_bool",
         ":drake_path",
@@ -132,6 +133,15 @@ drake_cc_library(
     deps = [
         ":cond",
         ":dummy_value",
+        ":essential",
+    ],
+)
+
+drake_cc_library(
+    name = "diagnostic_policy",
+    srcs = ["diagnostic_policy.cc"],
+    hdrs = ["diagnostic_policy.h"],
+    deps = [
         ":essential",
     ],
 )

--- a/common/diagnostic_policy.cc
+++ b/common/diagnostic_policy.cc
@@ -1,0 +1,44 @@
+#include "drake/common/diagnostic_policy.h"
+
+#include <stdexcept>
+#include <utility>
+
+#include "drake/common/text_logging.h"
+
+namespace drake {
+
+void DiagnosticPolicy::SetActionForWarnings(
+    std::function<void(const DiagnosticDetail&)> functor) {
+  on_warning_ = std::move(functor);
+}
+
+void DiagnosticPolicy::SetActionForErrors(
+    std::function<void(const DiagnosticDetail&)> functor) {
+  on_error_ = std::move(functor);
+}
+
+void DiagnosticPolicy::Warning(std::string message) const {
+  this->Warning(DiagnosticDetail({.message = std::move(message)}));
+}
+
+void DiagnosticPolicy::Error(std::string message) const {
+  this->Error(DiagnosticDetail({.message = std::move(message)}));
+}
+
+void DiagnosticPolicy::Warning(const DiagnosticDetail& detail) const {
+  if (on_warning_ == nullptr) {
+    log()->warn(detail.message);
+  } else {
+    on_warning_(detail);
+  }
+}
+
+void DiagnosticPolicy::Error(const DiagnosticDetail& detail) const {
+  if (on_error_ == nullptr) {
+    throw std::runtime_error(detail.message);
+  } else {
+    on_error_(detail);
+  }
+}
+
+}  // namespace drake

--- a/common/diagnostic_policy.h
+++ b/common/diagnostic_policy.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+
+/** Captures details about a warning or error condition.
+Additional member fields might be added in future revisions. */
+struct DiagnosticDetail {
+  std::string message;
+
+  // TODO(jwnimmer-tri) We probably should have some kind of to_string here
+  // that collects all member fields' information.
+};
+
+/** A structured mechanism for functions that accept untrustworthy data to
+report problems back to their caller.
+
+By default, warnings will merely be logged into drake::log(), and errors will
+throw exceptions.  The user can customize this behavior via the Set methods.
+
+Note in particular that the user's replacement error callback is not required
+to throw.  Code that calls policy.Error must be prepared to received control
+back from that method; typically, this means "return;" should follow its use.
+*/
+class DiagnosticPolicy {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DiagnosticPolicy)
+  DiagnosticPolicy() = default;
+
+  /** Trigger a warning. */
+  void Warning(std::string message) const;
+
+  /** Trigger an error. */
+  void Error(std::string message) const;
+
+  /** (Advanced.) Trigger a warning. */
+  void Warning(const DiagnosticDetail& detail) const;
+
+  /** (Advanced.) Trigger an error. */
+  void Error(const DiagnosticDetail& detail) const;
+
+  /** Setting to nullptr restores the default behavior (i.e., to log). */
+  void SetActionForWarnings(std::function<void(const DiagnosticDetail&)>);
+
+  /** Setting to nullptr restores the default behavior (i.e., to throw). */
+  void SetActionForErrors(std::function<void(const DiagnosticDetail&)>);
+
+ private:
+  std::function<void(const DiagnosticDetail&)> on_warning_;
+  std::function<void(const DiagnosticDetail&)> on_error_;
+};
+
+}  // namespace drake

--- a/geometry/proximity/BUILD.bazel
+++ b/geometry/proximity/BUILD.bazel
@@ -459,6 +459,7 @@ drake_cc_library(
     hdrs = ["obj_to_surface_mesh.h"],
     deps = [
         ":surface_mesh",
+        "//common:diagnostic_policy",
         "//common:essential",
         "@fmt",
         "@tinyobjloader",

--- a/geometry/proximity/obj_to_surface_mesh.cc
+++ b/geometry/proximity/obj_to_surface_mesh.cc
@@ -112,7 +112,7 @@ SurfaceMesh<double> DoReadObjToSurfaceMesh(
     std::istream* input_stream,
     const double scale,
     const std::optional<std::string>& mtl_basedir,
-    const std::function<void(std::string_view)> on_warning) {
+    const DiagnosticPolicy& diagnostic) {
   tinyobj::attrib_t attrib;  // Used for vertices.
   std::vector<tinyobj::shape_t> shapes;  // Used for triangles.
   std::vector<tinyobj::material_t> materials;  // Not used.
@@ -136,11 +136,7 @@ SurfaceMesh<double> DoReadObjToSurfaceMesh(
     if (warn.back() == '\n') {
       warn.pop_back();
     }
-    if (on_warning) {
-      on_warning(warn);
-    } else {
-      drake::log()->warn(warn);
-    }
+    diagnostic.Warning(warn);
   }
   if (shapes.size() == 0) {
     throw std::runtime_error("The Wavefront obj file has no faces.");
@@ -171,7 +167,7 @@ SurfaceMesh<double> DoReadObjToSurfaceMesh(
 SurfaceMesh<double> ReadObjToSurfaceMesh(
     const std::string& filename,
     const double scale,
-    std::function<void(std::string_view)> on_warning) {
+    const DiagnosticPolicy& diagnostic) {
   std::ifstream input_stream(filename);
   if (!input_stream.is_open()) {
     throw std::runtime_error("Cannot open file '" + filename +"'");
@@ -179,16 +175,16 @@ SurfaceMesh<double> ReadObjToSurfaceMesh(
   const std::string mtl_basedir =
       filesystem::path(filename).parent_path().string() + "/";
   return DoReadObjToSurfaceMesh(&input_stream, scale, mtl_basedir,
-                                std::move(on_warning));
+                                diagnostic);
 }
 
 SurfaceMesh<double> ReadObjToSurfaceMesh(
     std::istream* input_stream,
     const double scale,
-    std::function<void(std::string_view)> on_warning) {
+    const DiagnosticPolicy& diagnostic) {
   DRAKE_THROW_UNLESS(input_stream != nullptr);
   return DoReadObjToSurfaceMesh(input_stream, scale,
-      std::nullopt /* mtl_basedir */, std::move(on_warning));
+      std::nullopt /* mtl_basedir */, diagnostic);
 }
 
 }  // namespace geometry

--- a/geometry/proximity/obj_to_surface_mesh.h
+++ b/geometry/proximity/obj_to_surface_mesh.h
@@ -6,6 +6,7 @@
 #include <string_view>
 #include <vector>
 
+#include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/proximity/surface_mesh.h"
 
 namespace drake {
@@ -31,7 +32,7 @@ namespace geometry {
 SurfaceMesh<double> ReadObjToSurfaceMesh(
     const std::string& filename,
     double scale = 1.0,
-    std::function<void(std::string_view)> on_warning = {});
+    const DiagnosticPolicy& diagnostic = {});
 
 /**
  Overload of @ref ReadObjToSurfaceMesh(const std::string&, double) with the
@@ -40,7 +41,7 @@ SurfaceMesh<double> ReadObjToSurfaceMesh(
 SurfaceMesh<double> ReadObjToSurfaceMesh(
     std::istream* input_stream,
     double scale = 1.0,
-    std::function<void(std::string_view)> on_warning = {});
+    const DiagnosticPolicy& diagnostic = {});
 
 }  // namespace geometry
 }  // namespace drake

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -170,6 +170,7 @@ drake_cc_library(
     deps = [
         ":detail_sdf_parser",
         ":detail_urdf_parser",
+        "//common:diagnostic_policy",
         "//common:filesystem",
     ],
 )

--- a/multibody/parsing/detail_path_utils.cc
+++ b/multibody/parsing/detail_path_utils.cc
@@ -59,6 +59,7 @@ std::optional<string> GetPackagePath(
   if (package_map.Contains(package)) {
     return package_map.GetPath(package);
   } else {
+    // TODO(jwnimmer-tri) Use the DiagnosticPolicy here instead.
     drake::log()->warn("Couldn't find package '{}' in the supplied package"
                        "path: {}", package, package_map);
     return std::nullopt;

--- a/multibody/parsing/package_map.cc
+++ b/multibody/parsing/package_map.cc
@@ -141,6 +141,7 @@ void PackageMap::AddPackageIfNew(const string& package_name,
     // Don't warn if we've found the same path with a different spelling.
     const string existing_path = GetPath(package_name);
     if (!filesystem::equivalent(existing_path, path)) {
+      // TODO(jwnimmer-tri) Use the DiagnosticPolicy here instead.
       drake::log()->warn(
           "PackageMap is ignoring newly-found path \"{}\" for package \"{}\""
           " and will continue using the previously-known path at \"{}\".",
@@ -210,6 +211,7 @@ void PackageMap::CrawlForPackages(const string& path) {
   filesystem::directory_iterator iter(
       filesystem::path(path).lexically_normal(), ec);
   if (ec) {
+    // TODO(jwnimmer-tri) Use the DiagnosticPolicy here instead.
     log()->warn("Unable to open directory: {}", path);
     return;
   }

--- a/multibody/parsing/parser.cc
+++ b/multibody/parsing/parser.cc
@@ -30,6 +30,7 @@ FileType DetermineFileType(const std::string& file_name) {
   if ((ext == ".sdf") || (ext == ".SDF")) {
     return FileType::kSdf;
   }
+  // TODO(jwnimmer-tri) Use the DiagnosticPolicy here instead.
   throw std::runtime_error(fmt::format(
       "The file type '{}' is not supported for '{}'",
       ext, file_name));

--- a/multibody/parsing/parser.h
+++ b/multibody/parsing/parser.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "drake/common/diagnostic_policy.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/parsing/package_map.h"
 #include "drake/multibody/plant/multibody_plant.h"
@@ -32,6 +33,9 @@ class Parser final {
 
   /// Gets a mutable reference to the PackageMap used by this parser.
   PackageMap& package_map() { return package_map_; }
+
+  /// Gets a mutable reference to the DiagnosticPolicy used by this parser.
+  DiagnosticPolicy& diagnostic_policy() { return diagnostic_policy_; }
 
   /// Parses the SDF or URDF file named in @p file_name and adds all of its
   /// model(s) to @p plant.
@@ -82,6 +86,7 @@ class Parser final {
 
  private:
   PackageMap package_map_;
+  DiagnosticPolicy diagnostic_policy_;
   MultibodyPlant<double>* const plant_;
   geometry::SceneGraph<double>* const scene_graph_;
 };

--- a/systems/sensors/lcm_image_array_to_images.cc
+++ b/systems/sensors/lcm_image_array_to_images.cc
@@ -293,6 +293,7 @@ void LcmImageArrayToImages::CalcDepthImage(
       break;
     }
     default: {
+      // TODO(jwnimmer-tri) Use a DiagnosticPolicy here instead.
       drake::log()->error("Unsupported depth image channel type: {}",
                           lcm_image->channel_type);
       *depth_image = ImageDepth32F();


### PR DESCRIPTION
When a user asks us to parse untrustyworth data, we should allow them to
control how strict we should be.  If it was supposed to be error-free,
then we should allow them to fail-fast.  If they are just trying to bash
on regardless during protyping, then we should allow them to ignore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jwnimmer-tri/drake/7)
<!-- Reviewable:end -->
